### PR TITLE
 Fix mutable default argument warning in airtime method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.egg-info
 build/
 devnotes.md
+.idea/

--- a/intasend/transfers.py
+++ b/intasend/transfers.py
@@ -39,6 +39,8 @@ class Transfer(APIBase):
     def get_bank_codes(self):
         return self.send_request("GET", "send-money/bank-codes/ke/", {}, noauth=True)
     
-    def airtime(self, currency="KES", transactions=[], callback_url=None, wallet_id=None):
+    def airtime(self, currency="KES", transactions=None, callback_url=None, wallet_id=None):
+        if transactions is None:
+            transactions = []
         provider = "AIRTIME"
         return self.send_money(provider, currency, transactions, callback_url, wallet_id)


### PR DESCRIPTION

![image](https://github.com/IntaSend/intasend-python/assets/137799358/a7e8ba50-8b84-463d-90f1-6ce26d120d7a)

The warning "Default argument value is mutable" indicates a potential issue arising from the usage of mutable objects, such as lists or dictionaries, as default parameter values in function definitions. In Python, default argument values are evaluated only once at function definition time. Consequently, modifying the default value of the argument will impact all subsequent calls to that function, potentially leading to unintended side effects.

**Potential Consequences of the Scenario:**

In the original code, the airtime method utilizes a default mutable argument (transactions=[]) for the transactions parameter. While seemingly straight forward, this approach can lead to unexpected outcomes due to the shared state of mutable default arguments across multiple function calls.

**Consider the following scenario:**

```python
# Assuming we have a class instance named 'instance'
instance.airtime(transactions=[1, 2, 3])

```
Now, if the airtime method is invoked without explicitly passing a value for transactions, one might expect it to utilize an empty list by default. However, since lists are mutable, any modifications made to transactions inside the method will alter the default value. Consequently, subsequent invocations of the airtime method within the same runtime environment will inherit these modifications, potentially leading to unintended side effects.

For instance, if one call to airtime appends additional transaction data to transactions, all subsequent calls to airtime will carry over this appended data. This behavior violates the principle of encapsulation and can introduce subtle bugs that are challenging to debug.

**How to Reproduce:**

1. Observe the `airtime` method definition within the codebase.
2. Notice the usage of `transactions=[]` as the default argument.
3. Call the `airtime` method without explicitly passing a value for `transactions`.
4. Perform an action within the method that modifies the `transactions` list.

**Resolution Approach:**

To mitigate this issue, the `airtime` method has been refactored to use `None` as the default value for `transactions`. Within the method, a check is performed to ascertain if `transactions` is `None`. If so, it is explicitly initialized to an empty list. This modification ensures that each invocation of the method receives its distinct list object, thereby eliminating the risk of unintended side effects due to mutable default arguments. 

```python
def airtime(self, currency="KES", transactions=None, callback_url=None, wallet_id=None):
    if transactions is None:
        transactions = []
    provider = "AIRTIME"
    return self.send_money(provider, currency, transactions, callback_url, wallet_id)
```
@felixcheruiyot @mugendi-gitonga 