### PR TITLE
feat: Validate `transfer` transaction data

### DIFF
--- a/intasend/exceptions.py
+++ b/intasend/exceptions.py
@@ -12,3 +12,7 @@ class IntaSendUnauthorized(Exception):
 
 class IntaSendServerError(Exception):
     pass
+
+
+class NarrativeExceedsLengthLimit(ValueError):
+    pass

--- a/intasend/exceptions.py
+++ b/intasend/exceptions.py
@@ -12,7 +12,3 @@ class IntaSendUnauthorized(Exception):
 
 class IntaSendServerError(Exception):
     pass
-
-
-class NarrativeExceedsLengthLimit(ValueError):
-    pass

--- a/intasend/transfers.py
+++ b/intasend/transfers.py
@@ -1,3 +1,4 @@
+import warnings
 from __future__ import annotations
 from typing import Dict, Iterable
 
@@ -57,5 +58,5 @@ def _validate_transaction_data(transactions: Iterable[Dict[str, str]]) -> None:
     for transaction in transactions:
         if transaction['narrative']:
             if len(transaction['narrative']) > 22:
-                errmsg = "String values beyond 22 chars are truncated by default."
-                raise NarrativeExceedsLengthLimit(errmsg)
+                warn_msg = "String values beyond 22 chars are truncated in the confirmation sms by default."
+                warnings.warn(warn_msg)

--- a/intasend/transfers.py
+++ b/intasend/transfers.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+from typing import Dict, Iterable
+
+from intasend.exceptions import NarrativeExceedsLengthLimit
 from .client import APIBase
 
 class Transfer(APIBase):
@@ -10,6 +14,7 @@ class Transfer(APIBase):
             "callback_url": callback_url,
             "wallet_id": wallet_id
         }
+        _ = _validate_transaction_data(transactions)
         return self.send_request("POST", "send-money/initiate/", payload)
 
     def approve(self, payload):
@@ -45,3 +50,11 @@ class Transfer(APIBase):
             raise ValueError("Transantion details requiired")
         provider = "AIRTIME"
         return self.send_money(provider, currency, transactions, callback_url, wallet_id, requires_approval)
+
+
+def _validate_transaction_data(transactions: Iterable[Dict[str, str]]) -> None:
+    for transaction in transactions:
+        if transaction['narrative']:
+            if len(transaction['narrative']) > 22:
+                errmsg = "String values beyond 22 chars are truncated by default."
+                raise NarrativeExceedsLengthLimit(errmsg)

--- a/intasend/transfers.py
+++ b/intasend/transfers.py
@@ -6,6 +6,9 @@ from .client import APIBase
 
 class Transfer(APIBase):
     def send_money(self, provider, currency, transactions, callback_url=None, wallet_id=None, requires_approval='YES'):
+        if not transactions:
+            raise ValueError("Transaction details required")
+      
         payload = {
             "provider": provider,
             "currency": currency,
@@ -46,8 +49,6 @@ class Transfer(APIBase):
         return self.send_request("GET", "send-money/bank-codes/ke/", {}, noauth=True)
     
     def airtime(self, currency="KES", transactions=None, requires_approval="YES", callback_url=None, wallet_id=None):
-        if not transactions:
-            raise ValueError("Transantion details requiired")
         provider = "AIRTIME"
         return self.send_money(provider, currency, transactions, callback_url, wallet_id, requires_approval)
 

--- a/intasend/transfers.py
+++ b/intasend/transfers.py
@@ -1,8 +1,7 @@
-import warnings
 from __future__ import annotations
 from typing import Dict, Iterable
+import warnings
 
-from intasend.exceptions import NarrativeExceedsLengthLimit
 from .client import APIBase
 
 class Transfer(APIBase):

--- a/intasend/transfers.py
+++ b/intasend/transfers.py
@@ -17,7 +17,7 @@ class Transfer(APIBase):
             "callback_url": callback_url,
             "wallet_id": wallet_id
         }
-        _ = _validate_transaction_data(transactions)
+        _validate_transaction_data(transactions)
         return self.send_request("POST", "send-money/initiate/", payload)
 
     def approve(self, payload):


### PR DESCRIPTION
## Description
> This PR introduces patches to increase developer feedback and consequently user experience.

The `narrative` field on the transaction data used in the `transfer` module is truncated by default for strings that exceed 22 characters. No documentation or info about this behavior exists to inform developers concerning a _field_ used in the SMS notification for a successful transaction. This branch introduces a patch to _raise_ if a user attempts to use a string exceeding the limit to avoid incomplete or obscure data passed to the customer/end-user.

Fixes: `n/a`

Below are examples of truncated narratives in the SMS notification from Intasend on a successful transaction for a **live** account.

![truncated-narrative-airtime](https://github.com/user-attachments/assets/ddc8aecb-4037-4804-a53e-41d18d5dcd76)
![truncated-narrative-mpesa-b2c](https://github.com/user-attachments/assets/46c8da48-9c70-43e4-9200-56ba1d1fa50b)


### Decisions
> This section outlines notable considerations for developers/maintainers.
- Alternatively, logging a `warning` (non-blocking) may be more favorable to raising an exception (blocking). However, this requires configuring logging and that users observe these logs.

## Testing
The following unit test was written to validate the function responsible for raising the exception.  

```python
"""Throw away tests to validate transactions data """

import unittest

from intasend.transfers import _validate_transaction_data
from intasend.exceptions import NarrativeExceedsLengthLimit


class TestValidationTransactionData(unittest.TestCase):
    """Test individual transaction data is valid"""

    def setUp(self) -> None:
        self.transactions = [
            {"name": "test-name", "account": "0722222222", "amount": 10, "narrative": "fees"},
            {"name": "test-name", "account": "0722222222", "amount": 10000, "narrative": "fees"},
        ]
        return super().setUp()

    def test_should_raise_if_narrative_length_exceeds_expected_limit(self) -> None:
        # Given
        self.transactions[0]["narrative"] = "Exceeds max length of 22 chars"

        with self.assertRaises(NarrativeExceedsLengthLimit):  # Then
            _validate_transaction_data(self.transactions)  # When


if __name__ == "__main__":
    unittest()
```

**Note:** The test module was omitted from the PR given no tests are included in this package.

## Additional
**General**
- [Issues] The following areas for improvement were noted when working with this repo locally. Maintainers can check each item for approval and I can follow up with a subsequent PR to integrate the recommendations.

**Recommended change improvements:**
Check if applicable:
- [ ] (docs) Update transaction fields `account` and `amount` to use the correct type.
  The docs and example code for transaction data specify the fields `account` and `amount` as type `int` - which will result in a `400 BAD REQUEST` response - instead of the correct and expected type, `str`.
- [ ] (style) Format Python code, example, and docs code snippets with `black`.
  The codebase uses a custom format that is difficult to read. Using a recommended and opinionated formatter, such as [`black`](https://github.com/psf/black), ensures that the src resembles the majority of Python code, improving readability.
- [ ] (feat) Raise if the transaction field `amount` is below the minimum required, `10`.
  This applies the same validation logic used for the `narrative` field to increase user feedback.